### PR TITLE
Diff: Reduce tokenizer calls by coupling strings and token lengths in working queue

### DIFF
--- a/dotnet/src/SemanticKernel.Core/Text/TextChunker.cs
+++ b/dotnet/src/SemanticKernel.Core/Text/TextChunker.cs
@@ -32,6 +32,8 @@ public static class TextChunker
 
         public void Add(string value) => this.Values.Add((value, this._tokenCounter is null ? GetDefaultTokenCount(value.Length) : this._tokenCounter(value)));
 
+        public void Add(string value, int tokenCount) => this.Values.Add((value, tokenCount));
+
         public void AddRange(StringListWithTokenCount range)
         {
             this.Values.AddRange(range.Values);
@@ -337,13 +339,15 @@ public static class TextChunker
             }
         }
 
-        result.Add((inputString is not null, trim) switch
+        var resultString = inputString ?? input.ToString();
+        var resultTokenCount = inputTokenCount;
+        if (trim && !resultString.Trim().Equals(resultString, StringComparison.Ordinal))
         {
-            (true, true) => inputString!.Trim(),
-            (true, false) => inputString!,
-            (false, true) => input.Trim().ToString(),
-            (false, false) => input.ToString(),
-        });
+            resultString = resultString.Trim();
+            resultTokenCount = GetTokenCount(resultString, tokenCounter);
+        }
+
+        result.Add(resultString, resultTokenCount);
 
         return (result, inputWasSplit);
     }

--- a/dotnet/src/SemanticKernel.UnitTests/Text/TextChunkerInternationalTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Text/TextChunkerInternationalTests.cs
@@ -107,6 +107,6 @@ public sealed class TextChunkerInternationalTests
         await Verifier.Verify(result).UseParameters(language);
 
         Assert.True(counter.CallCount > 0);
-        Assert.True(counter.CallCount < story.Length);
+        Assert.True(counter.CallCount < story.Length / 2);
     }
 }

--- a/dotnet/src/SemanticKernel.UnitTests/Text/TextChunkerInternationalTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Text/TextChunkerInternationalTests.cs
@@ -100,13 +100,13 @@ public sealed class TextChunkerInternationalTests
     {
         var counter = new StatefulTokenCounter();
         var result = TextChunker.SplitPlainTextLines(story, 20, counter.Count);
+        Assert.True(counter.CallCount > 0);
+        Assert.True(counter.CallCount < story.Length / 2);
+
         foreach (var line in result)
         {
             Assert.True(counter.Count(line) <= 20);
         }
         await Verifier.Verify(result).UseParameters(language);
-
-        Assert.True(counter.CallCount > 0);
-        Assert.True(counter.CallCount < story.Length / 2);
     }
 }


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
